### PR TITLE
fixes image to RGB (no alpha)

### DIFF
--- a/coral-detect/index.js
+++ b/coral-detect/index.js
@@ -23,8 +23,9 @@ nstClient.addListener("open", () => {
             if (err) {
                 throw new Error(err);
             }
-
-            image.write("infile.png");
+            // setting colorType(2) forces the png to RGB (no alpha)
+            // the python reshape fails with RGBA images 
+            image.colorType(2).write("infile.png");
             await $`python3 detect_image.py -m ./test_data/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite -l ./test_data/coco_labels.txt -i infile.png -o /home/mendel/images/processed.png`
 
         });


### PR DESCRIPTION
the reshape was failing with errors like
```
ValueError: cannot reshape array of size 270000 into shape (225,300,3)
```

the python script was expecting images with 3 colors (no alpha).  this converts before writing infile.png